### PR TITLE
Add ability to connect to configurable digital twins instances

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,13 +12,13 @@
 
     <script type="text/javascript">
         // This is the URL of your DigitalTwins instance. It can be found in the Azure portal after deployment
-        var twinsInstanceRoot = "https://[instancename].[region].azuresmartspaces.net/";
+        var twinsInstanceRoot = " https://fviton-quickstart-prod.australiaeast.azuresmartspaces.net/";
 
         // This is the URI of your Azure Active Directory tenant.
-        var tenant = "contoso.onmicrosoft.com"; 
+        var tenant = "72f988bf-86f1-41af-91ab-2d7cd011db47"; 
 
         // This is the id of the application you've set up for DigitalTwins access:
-        var clientId = "00000000-0000-0000-0000-000000000000";
+        var clientId = "1f7b6d21-2122-4734-ad33-c19da44c41b5";
 
     </script>
 

--- a/app/index.html
+++ b/app/index.html
@@ -10,23 +10,13 @@
     <!-- Stylesheets requirements -->
     <link rel="stylesheet" href="style.css" />
 
-    <script type="text/javascript">
-        // This is the URL of your DigitalTwins instance. It can be found in the Azure portal after deployment
-        var twinsInstanceRoot = " https://fviton-quickstart-prod.australiaeast.azuresmartspaces.net/";
-
-        // This is the URI of your Azure Active Directory tenant.
-        var tenant = "72f988bf-86f1-41af-91ab-2d7cd011db47"; 
-
-        // This is the id of the application you've set up for DigitalTwins access:
-        var clientId = "1f7b6d21-2122-4734-ad33-c19da44c41b5";
-
-    </script>
-
     <!-- Script requirements -->
     <script src="https://code.jquery.com/jquery-latest.min.js"></script>
     <script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.5/jquery-ui.min.js'></script>
     <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.0/js/adal.min.js"></script>
     <script src="https://d3js.org/d3.v3.min.js"></script>
+    <script src="scripts/ajax.js"></script>
+    <script src="scripts/storage.js"></script>
     <script src="scripts/login.js"></script>
     <script src="scripts/infopanel.js"></script>
     <script src="scripts/graph.js"></script>
@@ -34,14 +24,18 @@
     <script type="text/javascript">
 
         $(function () {
+            // try to populate inputs from config from storage
+            prepopulateInputs();
 
-            // Let's login the user
-            authenticate();
+            if(getTwinsInstanceRoot() && getTwinsTenantId() && getTwinsClientId()){
+                authenticate();
+            }
             
             // If the user is logged in, let make sure we set everything.
             if (user) {
                 // Hide the welcome message and show the visualizer div that holds the visualization.
                 $("#notSignedInMessage").hide();
+                $("#twinsConfig").hide();
                 $("#visualizer").show();
                 $("#graphZoomSlider").show();
                 // Update the login container info
@@ -112,6 +106,18 @@
 
         });
 
+        function prepopulateInputs(){
+            var state = loadSavedStateFromStorage();
+            if(state.url){
+                $("#twinsUrl").val(state.url);
+            }
+            if(state.tenantId){
+                $("#twinsTenantId").val(state.tenantId);
+            }
+            if(state.clientId){
+                $("#twinsClientId").val(state.clientId);
+            }
+        }
     </script>
 
 
@@ -146,8 +152,30 @@
             <div>
                 <h1 class="icon"></h1>
                 <h1>You are not signed in.</h1>
-                <h3>Please sign in first so we can load the data.</h3>
+                <h3>Please fill in forms below and sign in first so we can load the data.</h3>
             </div>
+        </section>
+
+        <section id="twinsConfig" class="twins-config">
+                <div id="twinsConfigWrapper" class="twins-config-wrapper">
+                        <ul>
+                            <li class="list-item" style="">
+                                <label class="twins-config-label">Azure Digital Twins Instance Root Url
+                                <input id="twinsUrl" type="text" placeholder="https://[instancename].[region].azuresmartspaces.net/"/>
+                                </label>
+                            </li>
+                            <li class="list-item" style="">
+                                <label class="twins-config-label">Tenant Id
+                                <input id="twinsTenantId" type="text" placeholder="00000000-0000-0000-0000-000000000000"/>
+                                </label>
+                            </li>
+                            <li class="list-item" style="">
+                                <label class="twins-config-label">Client Id
+                                <input id="twinsClientId" type="text" placeholder="00000000-0000-0000-0000-000000000000"/>
+                                </label>
+                            </li>
+                        </ul>
+                </div>
         </section>
 
         <!-- Main Visualizer stuff -->

--- a/app/scripts/ajax.js
+++ b/app/scripts/ajax.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+var fetchAjax = function(paramsObj) {  
+    return new Promise((resolve, reject) => {
+      $.ajax(paramsObj)
+        .done((response) => resolve(response))
+        .fail((err) => reject(err));
+    });
+  } 

--- a/app/scripts/login.js
+++ b/app/scripts/login.js
@@ -1,56 +1,72 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-var endpoints = {};
-// No need to change this value, it belongs to the Azure DigitalTwins service
-endpoints[twinsInstanceRoot] = "0b07f429-9f4b-4714-9392-cc5e8e80c8b0";
 
 var pageUrl = window.location.href;
 var user, authContext, message, errorMessage, loginButton, logoutButton;
-var baseUrl = twinsInstanceRoot + "management/";
-
-window.config = {
-    tenant: tenant,
-    clientId: clientId,
-    postLogoutRedirectUri: pageUrl,
-    redirectUri: pageUrl,
-    endpoints: endpoints,
-    cacheLocation: 'localStorage' // enable this for IE, as sessionStorage does not work for localhost.
-};
 
 function authenticate() {
-    authContext = new AuthenticationContext(config);
+    var endpoints = {};
+    endpoints[getTwinsInstanceRoot()] = "0b07f429-9f4b-4714-9392-cc5e8e80c8b0";
+    var config = {
+        tenant: getTwinsTenantId(),
+        clientId: getTwinsClientId(),
+        postLogoutRedirectUri: pageUrl,
+        redirectUri: pageUrl,
+        endpoints: endpoints,
+        cacheLocation: 'localStorage' // enable this for IE, as sessionStorage does not work for localhost.
+    };
+
+    console.log("URL: " + getTwinsInstanceRoot());
+    console.log("Tenant: " + config.tenant);
+    console.log("Client: " + config.clientId);
+
+    var localAuthContext = new AuthenticationContext(config);
+    // When a previous AuthenticationContext has already been created in this session the
+    // config seems to be cached and reused, even when creating a new object with a new config
+    localAuthContext.config = config;
 
     // Check For & Handle Redirect From AAD After Login
-    var isCallback = authContext.isCallback(window.location.hash);
+    var isCallback = localAuthContext.isCallback(window.location.hash);
     if (isCallback) {
-        authContext.handleWindowCallback();
+        localAuthContext.handleWindowCallback();
     }
-    var loginError = authContext.getLoginError();
+    var loginError = localAuthContext.getLoginError();
 
     if (isCallback && !loginError) {
-        window.location = authContext._getItem(authContext.CONSTANTS.STORAGE.LOGIN_REQUEST);
+        window.location = localAuthContext._getItem(localAuthContext.CONSTANTS.STORAGE.LOGIN_REQUEST);
     }
     else {
         $("#errorMessage").text(loginError);
     }
-    user = authContext.getCachedUser();
+    user = localAuthContext.getCachedUser();
     // Doing this here, so it's already in the token cache when the 3 simultaneous ajax calls go out:
-    var resource = authContext.getResourceForEndpoint(baseUrl);
-    authContext.acquireToken(resource, function(error, token) { 
+    var resource = localAuthContext.getResourceForEndpoint(getBaseUrl());
+    localAuthContext.acquireToken(resource, function(error, token) {
         if(error || !token){
             handleTokenError(error);
         }
         else {
-            console.log("Succesfully retrieved token")} 
+            console.log("Succesfully retrieved token")}
         }
     );
+    if(user){
+        // only store the config and the context if we've authenticated the user
+        window.config = config;
+        authContext = localAuthContext;
+    }
+
+    return localAuthContext;
+}
+
+function getBaseUrl(){
+    return getTwinsInstanceRoot() + "management/";
 }
 
 function handleTokenError(error) {
     // Try to catch some common stuff that can go wrong
     if (error.startsWith("AADSTS50076")) {
-        // In this case, the user likely signed in on a location that did not require MFA and then move. 
+        // In this case, the user likely signed in on a location that did not require MFA and then move.
         console.log("MFA required but not used. Logging out.");
         logout();
     }
@@ -70,7 +86,10 @@ function handleTokenError(error) {
 }
 
 function login() {
-    authContext.login();
+    // try to store fields for easier access next time
+    saveStateToStorage($("#twinsUrl").val(), $("#twinsTenantId").val(), $("#twinsClientId").val());
+    var localAuthContext = authenticate();
+    localAuthContext.login();
 }
 
 function logout() {

--- a/app/scripts/storage.js
+++ b/app/scripts/storage.js
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+function loadSavedStateFromStorage(){
+    let state = {
+        url: "",
+        tenantId: "",
+        clientId: ""
+    };
+    if (typeof(Storage) !== "undefined") {                
+        state.url = localStorage.getItem("twinsUrl");
+        state.tenantId = localStorage.getItem("twinsTenant");
+        state.clientId = localStorage.getItem("twinsClient");
+    }
+    return state;
+}
+
+function saveStateToStorage(url, tenantId, clientId){
+    if (typeof(Storage) !== "undefined") {
+        localStorage.setItem("twinsUrl", url);
+        localStorage.setItem("twinsTenant", tenantId);
+        localStorage.setItem("twinsClient", clientId);                
+    }
+}
+
+function getTwinsInstanceRoot(){
+    return localStorage.getItem("twinsUrl");
+}
+
+function getTwinsTenantId(){
+    return localStorage.getItem("twinsTenant");
+}
+
+function getTwinsClientId(){
+    return localStorage.getItem("twinsClient");
+}

--- a/app/style.css
+++ b/app/style.css
@@ -82,6 +82,25 @@ select {
     width: 100%;
 }
 
+.list-item{
+    clear:left;
+    list-style:none;
+}
+
+div.twins-config-wrapper {
+    width: 50%;
+}
+
+section.twins-config {
+    height: 30%;
+    justify-content: center;
+    display: inline-flex;
+}
+
+label.twins-config-label {
+    width: 100%;
+}
+
 input:disabled {
     color: rgba(255,255,255,0.4);
 }


### PR DESCRIPTION
- Add ability to connect to configurable digital twins instances via input fields on signed out view
- Fix issue preventing loading of graphs with > 1000 spaces. Current approach is to work our way down the hierarchy, splitting up the descendant calls by each space at that level, and working our way down the levels until query succeeds or we run out of space levels. 

Note: this fix is only for spaces. We still cannot query for > 1000 devices or sensors, but they should be able to follow the same approach of using a space at some point in the tree, and traversing down to grab all of its descendant devices - we would just need to find the appropriate level of the tree to query from