### PR TITLE
Fix AADSTS50058 error when using AAD guest account

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,7 @@
     <!-- Script requirements -->
     <script src="https://code.jquery.com/jquery-latest.min.js"></script>
     <script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.5/jquery-ui.min.js'></script>
-    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.0/js/adal.min.js"></script>
+    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.17/js/adal.min.js"></script>
     <script src="https://d3js.org/d3.v3.min.js"></script>
     <script src="scripts/storage.js"></script>
     <script src="scripts/login.js"></script>


### PR DESCRIPTION
The following error occurred in the console of the application after signing in:
```login.js:20 URL: https://<redacted>.westeurope.azuresmartspaces.net/
login.js:21 Tenant: <redacted>
login.js:22 Client: <redacted>
adal.min.js:2 renewToken is failed:AADSTS50058: A silent sign-in request was sent but none of the currently signed in user(s) match the requested login hint.
Trace ID: <redacted>
Correlation ID: <redacted>
Timestamp: 2019-06-17 11:04:26Z
login.js:75 A silent sign-in request was sent but no user is signed in. Setting UI to logged out state.
```

After limited testing it appears it's due to having a guest account in the target Azure AD. Updating the ADAL library to a newer version resolves the issue.